### PR TITLE
Semantic refactor

### DIFF
--- a/change_quotes.py
+++ b/change_quotes.py
@@ -119,8 +119,8 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
             unescape = '"'
 
         self.view.sel().subtract(region)
-        self.view.replace(edit, sublime.Region(a, a + len(replacement_a)), replacement_a)
-        self.view.replace(edit, sublime.Region(b, b + len(replacement_b)), replacement_b)
+        self.view.replace(edit, sublime.Region(a, a + len(quote_a)), replacement_a)
+        self.view.replace(edit, sublime.Region(b, b + len(quote_b)), replacement_b)
 
         if escape:
             # escape "escape" with "\escape"


### PR DESCRIPTION
Although this PR doesn't change, how the plugin works, it is only because the quotes are of the same length as the replacements. The commit shows our true intention, which is to adjust the indices taking the value of the current text length (`quotes_a/b`) and not of the replacement text length.

(I'm working on version of the plugin for LiveScript, where the length of `quote_b` changes.)