### PR TITLE
Rework to allow a flexible, user-configurable list of quotes

### DIFF
--- a/ChangeQuotes.sublime-settings
+++ b/ChangeQuotes.sublime-settings
@@ -1,5 +1,6 @@
 {
-  "quote_lists": {
+  "debug": true,
+  "lists": {
     "default": {
       "prefixes": [],
       "quotes": [["'", "\""]],

--- a/ChangeQuotes.sublime-settings
+++ b/ChangeQuotes.sublime-settings
@@ -1,0 +1,16 @@
+{
+  "quote_lists": {
+    "default": {
+      "prefixes": [],
+      "quotes": [["'", "\""]],
+    },
+    "source.python": {
+      "prefixes": ["u", "r", "ur"],
+      "quotes": [["'", "\""], ["'''", "\"\"\""]]
+    },
+    "source.js": {
+      "prefixes": [],
+      "quotes": [["'", "\"", "`"]],
+    }
+  }
+}

--- a/ChangeQuotes.sublime-settings
+++ b/ChangeQuotes.sublime-settings
@@ -1,17 +1,18 @@
 {
-  "debug": true,
+  "debug": false,
   "lists": {
     "default": {
-      "prefixes": [],
-      "quotes": [["'", "\""]],
+      "quotes": [["'", "\""]]
     },
     "source.python": {
-      "prefixes": ["u", "r", "ur"],
+      "prefixes": [
+        "r", "u", "ur", "R", "U", "UR", "Ur", "uR",
+        "b", "B", "br", "Br", "bR", "BR"
+      ],
       "quotes": [["'", "\""], ["'''", "\"\"\""]]
     },
     "source.js": {
-      "prefixes": [],
-      "quotes": [["'", "\"", "`"]],
+      "quotes": [["'", "\"", "`"]]
     }
   }
 }

--- a/Main.sublime-menu.json
+++ b/Main.sublime-menu.json
@@ -1,0 +1,38 @@
+[
+  {
+    "caption": "Preferences",
+    "mnemonic": "n",
+    "id": "preferences",
+    "children": [
+      {
+        "caption": "Package Settings",
+        "mnemonic": "P",
+        "id": "package-settings",
+        "children": [
+          {
+            "caption": "Change Quotes",
+            "children": [
+              {
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/ChangeQuotes/ChangeQuotes.sublime-settings"
+                },
+                "caption": "Settings – Default"
+              },
+              {
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/User/ChangeQuotes.sublime-settings"
+                },
+                "caption": "Settings – User"
+              },
+              {
+                "caption": "-"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/change_quotes.py
+++ b/change_quotes.py
@@ -13,16 +13,16 @@ config = None  # mute F821 errors from flake8
 
 
 def reorder_list_settings(list_settings):
-    """Reorder the quotes arrays and the prefixes list.
+    """Reorder the quotes lists and the prefixes list.
 
     The reordering of the quotes lists is as follows:
       - Each quote list's elements (quotes) are ordered by len(quote)
       - The quote lists's elements (quote_lists) are ordered len(quote_list[0])
 
     The reordering of the prefix list is as follows:
-      - The prefix list's elements (chars) are ordered by len(char)
+      - The prefix list's elements (prefixes) are ordered by len(prefix)
 
-    The order is important, because a that a ''' must take precedence over '
+    The order is important, because a ''' must take precedence over '
     (otherwise '''foo bar''' will get replaced by ''"foo bar"'')
 
     Returns the sorted settings.
@@ -49,9 +49,9 @@ def build_config(settings):
 
     This is required since the original settings need to be reordered
     before they are used, which can't happen directly
-    (sublime's settings are note mutable)
+    (sublime's settings are immutable)
 
-    Returns a dict representing the sublime settings.
+    Returns a dict representing the reordered settings.
 
     """
     global config
@@ -138,9 +138,9 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
     def apply_scope(self, cursor):
         """Choose the best-matching quote and prefix lists.
 
-        Start by choosing the default lists.
+        Start by choosing the default ones.
         Then, for syntax-specific lists, evaluate the syntax
-        match score and possibly choose those lists instead.
+        match score and possibly choose them instead.
 
         Chosen values are stored in self.quotes and self.prefixes.
 
@@ -397,8 +397,8 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
     def build_regions(self, region, text, match_data, quote, replacement):
         """Divide `region` into 3 sub-regions: start, end and inner.
 
-        The start region contains only the quote chars at the left border
-        The end region contains only the quote chars at the right border
+        The start region contains only the quote chars at the left border.
+        The end region contains only the quote chars at the right border.
         The inner region contains the text inbetween.
 
         Returned value is a dict:

--- a/change_quotes.py
+++ b/change_quotes.py
@@ -121,6 +121,10 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
             replacement
         )
 
+        # Edge case in which there is no closing quote
+        if regions["start"].contains(regions["end"]):
+            return
+
         # Altering the region lengths (e.g. replacing ' with ''') will cause
         # their right boundary to move further to the right, which
         # causes issues as the boundaries no longer match the pre-calculated

--- a/change_quotes.py
+++ b/change_quotes.py
@@ -6,7 +6,6 @@ import sublime_plugin
 import re
 import itertools
 
-
 ST3 = int(sublime.version()) >= 3000
 
 global config
@@ -33,7 +32,7 @@ def reorder_list_settings(list_settings):
         prefixes = conf.get("prefixes", [])
         quote_lists = conf.get("quotes", [])
 
-        # In the sub-lists, place the longest item furst
+        # In the sub-lists, place the longest item first
         for ql in quote_lists:
             ql.sort(key=len, reverse=True)
 
@@ -229,10 +228,10 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
         return region
 
     def expand_to_match(self, ref):
-        """Expand `ref` to the closest region, surrounded by quotes.
+        """Expand `ref` to the innermost region, surrounded by quotes.
 
-        Expansion is done by searching for any of the chars in in each
-        quotes_list in self.quote_lists. Search is both left and right,
+        Expansion is done by searching for any of the chars in each
+        list in self.quote_lists. Search is both to the left and right,
         up to the current scope extents. Then, the constructed regions
         are compared and the one closest to `ref` boundary is returned.
 


### PR DESCRIPTION
Hello

This is something I developed to originally address #20.
It turned out quite big as I had to change the main logic behind the plugin for the purpose.

So this is basically a rework in order to resolve the following issues:
* a code change (and a new version) of the plugin must be released every time the quote list needs to be changed
* a maximum of one alternation is supported (but, for example, ES6 defines three ways to quote a string: `'`, `"` and `` ` ``)
* it is not clear which quotes apply to which language, but different languages allow different quotes

I have also introduced a:
* Configuration file: it allows to configure the quotes to alternate between on a per-scope basis
* Menu entry: in `Package Settings` there is now a `Change Quotes` sub-menu which allows to open the default/user settings

The default configuration file has the following contents:

    {
      "debug": false,
      "lists": {
        "default": {
          "prefixes": [],
          "quotes": [["'", "\""]]
        },
        "source.python": {
          "prefixes": [
            "r", "u", "ur", "R", "U", "UR", "Ur", "uR",
            "b", "B", "br", "Br", "bR", "BR"
          ],
          "quotes": [["'", "\""], ["'''", "\"\"\""]]
        },
        "source.js": {
          "prefixes": [],
          "quotes": [["'", "\"", "`"]]
        }
      }
    }

The `debug` flag makes the plugin noisy -- for development purposes.

The `lists` object is the one a user would typically edit. Each key represents a scope, each value -- the config for that scope (a list of quotes and optionally prefixes). For example:

    "source.js": {
      "quotes": [["'", "\"", "`"]]
    }

This tells the plugin to alternate between `'`, `"` and `` ` `` within a `source.js` context.
Note that `quotes` is an array of arrays -- it is used to logically separate different quote groups (see the `source.python` config below)

For python, the config also specifies a list of possible "string prefixes":

    "source.python": {
      "prefixes": [
        "r", "u", "ur", "R", "U", "UR", "Ur", "uR",
        "b", "B", "br", "Br", "bR", "BR"
      ],
      "quotes": [["'", "\""], ["'''", "\"\"\""]]
    }

This tells the plugin to alternate between `'` and `"` or between `'''` and `"""`, but not between `'` and `'''`, within a `source.python` context.
It allso tells the plugin to take some string prefixes into account (like `u'some string'`). For now, this setting only makes sense for python and can be empty (or ommitted) for other languages.

For all other scopes (comments, plain text, etc.), there is a `default` config section.

It is important to note that a user, upgrading to this new version, wont be forced to manually configure anything (the plugin should work similar to before).

I was ready with it weeks ago, but wanted to polish and test it on my own for a while. So far it seems good, but I'd love it if other people could share their comments.

Feedback is most welcome!

I hope you like it ^_^
