### PR TITLE
LiveScript fixes + escaping fix

### DIFF
--- a/ChangeQuotes.sublime-settings
+++ b/ChangeQuotes.sublime-settings
@@ -4,6 +4,10 @@
     "default": {
       "quotes": [["'", "\""]]
     },
+    "source.livescript": {
+      "custom": ["livescript"],
+      "quotes": [["'", "\""]]
+    },
     // "source.js": {
     //   "quotes": [["'", "\"", "`"]]
     // },


### PR DESCRIPTION
Thanks for the startup.
I've fixed the following backslash string issues:
- support for `\)foo` strings
- disallowing empty backslash strings
- proper (un)escaping while converting to/from a backslash string
- proper escaping standalone trailing backslashes in `\foo\` like strings

I also fixed the escaping method, which was incorrectly trying to escape already escaped characters, like in `'\"'` -> `"\\""`.

Also added support for LiveScript triple quote strings, like `'''foo'''`.

I'm also thinking about adding the "pushing behavior" under the flag. What do you think? Is it an overkill?