### PR TITLE
LiveScript fixes + escaping fix

### DIFF
--- a/ChangeQuotes.sublime-settings
+++ b/ChangeQuotes.sublime-settings
@@ -6,7 +6,7 @@
     },
     "source.livescript": {
       "custom": ["livescript"],
-      "quotes": [["'", "\""]]
+      "quotes": [["'", "\""], ["'''", "\"\"\""]]
     },
     // "source.js": {
     //   "quotes": [["'", "\"", "`"]]

--- a/change_quotes.py
+++ b/change_quotes.py
@@ -502,8 +502,11 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
         self.view.replace(self.edit, region, inner_text)
 
     def livescript(self, region):
-        first_char = self.view.substr(sublime.Region(region.begin(), region.begin() + 1))
-        if first_char == '\\':
+        first_3_chars = self.view.substr(sublime.Region(region.begin(), region.begin() + 3))
+        first_char = first_3_chars[0]
+        if first_3_chars in ("'''", '"""'):
+            return 'next'
+        elif first_char == '\\':
             inner = self.view.substr(sublime.Region(region.begin() + 1, region.end()))
             replacement = "'%s'" % (inner)
             self.view.replace(self.edit, region, replacement)

--- a/change_quotes.py
+++ b/change_quotes.py
@@ -486,20 +486,21 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
         """
         debug("Replace %s with %s in %s" % (quote, replacement, region))
         inner_text = self.view.substr(region)
+        even_backslashes_re = r"(?<!\\)((?:\\\\)*)"
 
         # ESCAPE already existing new quotes in the inner region
         if replacement:
-            unesc_quote = replacement
-            unesc_replacement = re.sub(r"(.)", r"\\\g<1>", unesc_quote)
+            unesc_quote = even_backslashes_re + re.escape(replacement)
+            unesc_replacement = r"\g<1>" + re.sub(r"(.)", r"\\\g<1>", replacement)
             debug("Escape: replace %s with %s" % (unesc_quote, unesc_replacement))
-            inner_text = inner_text.replace(unesc_quote, unesc_replacement)
+            inner_text = re.sub(unesc_quote, unesc_replacement, inner_text)
 
-        # UNESCAPE escaped old quotes in the inner reagion
+        # UNESCAPE escaped old quotes in the inner region
         if quote:
-            esc_quote = re.sub(r"(.)", r"\\\g<1>", quote)
-            esc_replacement = quote
-            debug("Unesacpe: Replace %s with %s" % (esc_quote, esc_replacement))
-            inner_text = inner_text.replace(esc_quote, esc_replacement)
+            esc_quote = even_backslashes_re + re.escape(re.sub(r"(.)", r"\\\g<1>", quote))
+            esc_replacement = r"\g<1>" + quote
+            debug("Unescape: replace %s with %s" % (esc_quote, esc_replacement))
+            inner_text = re.sub(esc_quote, esc_replacement, inner_text)
 
         self.view.replace(self.edit, region, inner_text)
 

--- a/change_quotes.py
+++ b/change_quotes.py
@@ -512,7 +512,9 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
             self.view.replace(self.edit, region, replacement)
         elif first_char == '"':
             inner = self.view.substr(sublime.Region(region.begin() + 1, region.end() - 1))
-            inner_test = re.compile(r"[)\]},; \t\n\r]")
+            if inner == '':
+                return 'next'
+            inner_test = re.compile(r"^.+[)\]},; \t\n\r]")
             if inner_test.search(inner):
                 return 'next'
             next_char = self.view.substr(sublime.Region(region.end(), region.end() + 1))

--- a/change_quotes.py
+++ b/change_quotes.py
@@ -515,7 +515,7 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
             inner_region = sublime.Region(region.begin() + 1, region.end())
             inner = self.view.substr(inner_region)
             replacement = "'%s'" % (inner)
-            self.view.replace(self.edit, region, replacement)
+            self.replace_quotes(region, replacement)
             self.escape_unescape(inner_region, None, r"\\", r"\\$")
             self.escape_unescape(inner_region, None, "'")
         elif first_char == '"':
@@ -531,7 +531,7 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
             if next_test.search(next_char):
                 return 'next'
             replacement = "\\%s" % (inner)
-            self.view.replace(self.edit, region, replacement)
+            self.replace_quotes(region, replacement)
             self.escape_unescape(inner_region, '"', None)
         else:
             return 'next'

--- a/change_quotes.py
+++ b/change_quotes.py
@@ -488,16 +488,18 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
         inner_text = self.view.substr(region)
 
         # ESCAPE already existing new quotes in the inner region
-        unesc_quote = replacement
-        unesc_replacement = re.sub(r"(.)", r"\\\g<1>", unesc_quote)
-        debug("Escape: replace %s with %s" % (unesc_quote, unesc_replacement))
-        inner_text = inner_text.replace(unesc_quote, unesc_replacement)
+        if replacement:
+            unesc_quote = replacement
+            unesc_replacement = re.sub(r"(.)", r"\\\g<1>", unesc_quote)
+            debug("Escape: replace %s with %s" % (unesc_quote, unesc_replacement))
+            inner_text = inner_text.replace(unesc_quote, unesc_replacement)
 
         # UNESCAPE escaped old quotes in the inner reagion
-        esc_quote = re.sub(r"(.)", r"\\\g<1>", quote)
-        esc_replacement = quote
-        debug("Unesacpe: Replace %s with %s" % (esc_quote, esc_replacement))
-        inner_text = inner_text.replace(esc_quote, esc_replacement)
+        if quote:
+            esc_quote = re.sub(r"(.)", r"\\\g<1>", quote)
+            esc_replacement = quote
+            debug("Unesacpe: Replace %s with %s" % (esc_quote, esc_replacement))
+            inner_text = inner_text.replace(esc_quote, esc_replacement)
 
         self.view.replace(self.edit, region, inner_text)
 
@@ -507,11 +509,14 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
         if first_3_chars in ("'''", '"""'):
             return 'next'
         elif first_char == '\\':
-            inner = self.view.substr(sublime.Region(region.begin() + 1, region.end()))
+            inner_region = sublime.Region(region.begin() + 1, region.end())
+            inner = self.view.substr(inner_region)
             replacement = "'%s'" % (inner)
             self.view.replace(self.edit, region, replacement)
+            self.escape_unescape(inner_region, None, "'")
         elif first_char == '"':
-            inner = self.view.substr(sublime.Region(region.begin() + 1, region.end() - 1))
+            inner_region = sublime.Region(region.begin() + 1, region.end() - 1)
+            inner = self.view.substr(inner_region)
             if inner == '':
                 return 'next'
             inner_test = re.compile(r"^.+[)\]},; \t\n\r]")
@@ -523,6 +528,7 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
                 return 'next'
             replacement = "\\%s" % (inner)
             self.view.replace(self.edit, region, replacement)
+            self.escape_unescape(inner_region, '"', None)
         else:
             return 'next'
 

--- a/change_quotes.py
+++ b/change_quotes.py
@@ -509,26 +509,20 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
     def livescript(self, region):
         first_3_chars = self.view.substr(sublime.Region(region.begin(), region.begin() + 3))
         first_char = first_3_chars[0]
-        if first_3_chars in ("'''", '"""'):
-            return 'next'
-        elif first_char == '\\':
+        if first_char == '\\':
             inner_region = sublime.Region(region.begin() + 1, region.end())
             inner = self.view.substr(inner_region)
             replacement = "'%s'" % (inner)
             self.replace_quotes(region, replacement)
             self.escape_unescape(inner_region, None, r"\\", r"\\$")
             self.escape_unescape(inner_region, None, "'")
-        elif first_char == '"':
+        elif first_char == '"' and first_3_chars != '"""':
             inner_region = sublime.Region(region.begin() + 1, region.end() - 1)
             inner = self.view.substr(inner_region)
-            if inner == '':
-                return 'next'
             inner_test = re.compile(r"^.+[)\]},;\s]")
-            if inner_test.search(inner):
-                return 'next'
             next_char = self.view.substr(sublime.Region(region.end(), region.end() + 1))
             next_test = re.compile(r"[^)\]},;\s]")
-            if next_test.search(next_char):
+            if inner == '' or inner_test.search(inner) or next_test.search(next_char):
                 return 'next'
             replacement = "\\%s" % (inner)
             self.replace_quotes(region, replacement)

--- a/change_quotes.py
+++ b/change_quotes.py
@@ -523,11 +523,11 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
             inner = self.view.substr(inner_region)
             if inner == '':
                 return 'next'
-            inner_test = re.compile(r"^.+[)\]},; \t\n\r]")
+            inner_test = re.compile(r"^.+[)\]},;\s]")
             if inner_test.search(inner):
                 return 'next'
             next_char = self.view.substr(sublime.Region(region.end(), region.end() + 1))
-            next_test = re.compile(r"[^)\]},; \t\n\r]")
+            next_test = re.compile(r"[^)\]},;\s]")
             if next_test.search(next_char):
                 return 'next'
             replacement = "\\%s" % (inner)

--- a/change_quotes.py
+++ b/change_quotes.py
@@ -462,7 +462,7 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
         debug("Replace: %s with %s" % (self.view.substr(region), replacement))
         self.view.replace(self.edit, region, replacement)
 
-    def escape_unescape(self, region, quote, replacement):
+    def escape_unescape(self, region, quote, replacement, replacement_re = None):
         r"""In `region`, escape `replacement` and unescape `quote`.
 
         The escaped values are constructed from `replacement` by prepending
@@ -490,7 +490,9 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
 
         # ESCAPE already existing new quotes in the inner region
         if replacement:
-            unesc_quote = even_backslashes_re + re.escape(replacement)
+            if not replacement_re:
+                replacement_re = re.escape(replacement)
+            unesc_quote = even_backslashes_re + replacement_re
             unesc_replacement = r"\g<1>" + re.sub(r"(.)", r"\\\g<1>", replacement)
             debug("Escape: replace %s with %s" % (unesc_quote, unesc_replacement))
             inner_text = re.sub(unesc_quote, unesc_replacement, inner_text)
@@ -514,6 +516,7 @@ class ChangeQuotesCommand(sublime_plugin.TextCommand):
             inner = self.view.substr(inner_region)
             replacement = "'%s'" % (inner)
             self.view.replace(self.edit, region, replacement)
+            self.escape_unescape(inner_region, None, r"\\", r"\\$")
             self.escape_unescape(inner_region, None, "'")
         elif first_char == '"':
             inner_region = sublime.Region(region.begin() + 1, region.end() - 1)


### PR DESCRIPTION
Thanks for the startup.
I've fixed the following backslash string issues:
- support for `\)foo` strings
- disallowing empty backslash strings
- proper (un)escaping while converting to/from a backslash string
- proper escaping standalone trailing backslashes in `\foo\` like strings

I also fixed the escaping method, which was incorrectly trying to escape already escaped characters, like in `'\"'` -> `"\\""`.

Also added support for LiveScript triple quote strings, like `'''foo'''`.

I'm also thinking about adding the "pushing behavior" under the flag. What do you think? Is it an overkill?