### PR TITLE
Triple quotes in CoffeeScript files

### DIFF
--- a/ChangeQuotes.sublime-settings
+++ b/ChangeQuotes.sublime-settings
@@ -7,6 +7,12 @@
     // "source.js": {
     //   "quotes": [["'", "\"", "`"]]
     // },
+    "source.coffee": {
+      "quotes": [["'", "\""], ["'''", "\"\"\""]]
+    },
+    "source.litcoffee": {
+      "quotes": [["'", "\""], ["'''", "\"\"\""]]
+    },
     "source.python": {
       "prefixes": [
         "r", "u", "ur", "R", "U", "UR", "Ur", "uR",


### PR DESCRIPTION
I'm not sure, if current way of defining scopes is optimal. There could be many exact settings for multiple scope tags, e.g. CoffeeScript files here. A list of settings, each with a list of scopes could be better.

On the other hand the gain seems to be small and that would be a breaking change for existing user settings.